### PR TITLE
04.ls arl

### DIFF
--- a/04.ls/ls
+++ b/04.ls/ls
@@ -13,21 +13,22 @@ end
 
 # 結果を出力
 def output(path, is_dotmatch, is_reversed, is_detailed)
+  path_names = path_names_from_path(path, is_dotmatch)
+  path_names.reverse! if is_reversed
+  is_detailed ? ls_detailed(path_names) : ls(path_names)
+end
+
+# コマンドライン引数のパスからディレクトリパスの配列を取得
+def path_names_from_path(path, is_dotmatch)
   if path.nil? # nil
-    path_names = Dir.glob('*')
+    Dir.glob('*', is_dotmatch ? File::FNM_DOTMATCH : 0)
   elsif FileTest.directory? path # directory
-    path_names = Dir.glob(File.join(path, '*'))
+    Dir.glob(File.join(path, '*'), is_dotmatch ? File::FNM_DOTMATCH : 0)
   elsif FileTest.file? path # file
-    path_names = [path]
+    [path]
   else
     puts "ls: #{ARGV[0]}: No such file or directory"
     exit
-  end
-
-  if is_detailed
-    ls_detailed(path_names)
-  else
-    ls(path_names)
   end
 end
 

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -5,11 +5,14 @@ require 'optparse'
 require 'etc'
 require 'date'
 
-OPTIONS = ARGV.getopts('l')
+OPTIONS = ARGV.getopts('a', 'r', 'l')
 
 def main
-  path = ARGV[0]
+  output(ARGV[0], OPTIONS['a'], OPTIONS['r'], OPTIONS['l'])
+end
 
+# 結果を出力
+def output(path, is_dotmatch, is_reversed, is_detailed)
   if path.nil? # nil
     path_names = Dir.glob('*')
   elsif FileTest.directory? path # directory
@@ -21,11 +24,6 @@ def main
     exit
   end
 
-  output(path_names, OPTIONS['l'])
-end
-
-# 結果を出力
-def output(path_names, is_detailed)
   if is_detailed
     ls_detailed(path_names)
   else

--- a/04.ls/ls
+++ b/04.ls/ls
@@ -20,10 +20,11 @@ end
 
 # コマンドライン引数のパスからディレクトリパスの配列を取得
 def path_names_from_path(path, is_dotmatch)
+  dotmatch_pattern = is_dotmatch ? File::FNM_DOTMATCH : 0
   if path.nil? # nil
-    Dir.glob('*', is_dotmatch ? File::FNM_DOTMATCH : 0)
+    Dir.glob('*', dotmatch_pattern)
   elsif FileTest.directory? path # directory
-    Dir.glob(File.join(path, '*'), is_dotmatch ? File::FNM_DOTMATCH : 0)
+    Dir.glob(File.join(path, '*'), dotmatch_pattern)
   elsif FileTest.file? path # file
     [path]
   else


### PR DESCRIPTION
# やったこと
- ls5（arl複数オプションに対応）を実装
- 上記実装にあたり以下をリファクタ
  - mainメソッドからはoutputメソッドだけを呼ぶようにし、outputメソッドの引数として、各コマンドライン引数およびオプションを受け付けることとした（可読性に配慮）
  - 新たにpath_names_frompathメソッドを作成し、outputメソッドからpath（コマンドライン引数）による分岐の結果を呼び出すことにした（rubocop対応「Perceived complexity ≦ 8」にて）

レビューのほどお願いします！